### PR TITLE
feat: deploy games to GitHub Pages at jsgames domain

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+# Deploys the static games site (./src) to GitHub Pages at
+# https://jsgames.cristianofaustino.me
+name: Deploy to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # The site is static (no build step): upload ./src as-is and deploy
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Pages
+        uses: actions/configure-pages@v6
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ./src
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI agents (and humans) working on this repo.
 
 ## What this is
 
-A collection of small browser games written in vanilla JavaScript (ES modules, no framework, no build step), rendered on an HTML `<canvas>`. A minimal Express server ([index.js](index.js)) serves the static files under `src/`.
+A collection of small browser games written in vanilla JavaScript (ES modules, no framework, no build step), rendered on an HTML `<canvas>`. A minimal Express server ([index.js](index.js)) serves the static files under `src/` for local development. Production is GitHub Pages: [.github/workflows/pages.yml](.github/workflows/pages.yml) deploys `src/` to https://jsgames.cristianofaustino.me on every push to `main` — asset paths must stay root-absolute (`/common/...`) or root-relative for both to work.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ pnpm start
 ```
 
 It will listen on port `4000` by default, it can be configured through the `PORT` environmental variable too.
+
+## Deployment
+
+The games are deployed to GitHub Pages at [jsgames.cristianofaustino.me](https://jsgames.cristianofaustino.me) on every push to `main`.


### PR DESCRIPTION
Deploys the static games site (src/) to GitHub Pages at https://jsgames.cristianofaustino.me on every push to main, mirroring the Pages setup used by the blog repo. Express (index.js) remains the local dev server only. Pages is already enabled on the repo with build_type=workflow and the custom domain set; the only remaining step is a DNS CNAME record for jsgames pointing to cristiadu.github.io.