### PR TITLE
ci: run CI on Node 24 LTS instead of end-of-life Node 23

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [23.x]
+        node-version: [24.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
**Why:** CI currently runs on Node 23.x, an odd-numbered (non-LTS) release line that reached end-of-life in June 2025 and no longer receives security or bug fixes. Industry practice is to run CI on an active LTS line so the pipeline matches a supported production runtime.

**How:** Bumps the `node-version` matrix entry in `node.js.yml` from `23.x` to `24.x`, the current active LTS. No other workflow changes.