### PR TITLE
chore: lint the whole repo and use pnpm in doc commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ The project uses pnpm (version pinned via `packageManager` in [package.json](pac
 ```bash
 pnpm install     # install dependencies
 pnpm start       # serve on http://localhost:4000 (override with PORT)
-pnpm run lint    # eslint over ./src/**
+pnpm run lint    # eslint over the whole repo
 pnpm run lint:fix
 ```
 
@@ -71,6 +71,6 @@ The landing page [src/index.html](src/index.html) links to each game. When addin
 ## Conventions
 
 - ES modules everywhere; imports include the `.js` extension (enforced by `import-x/extensions`).
-- No semicolons, 2-space indent, max line length 140 — enforced by [eslint.config.js](eslint.config.js); run `npm run lint` before committing.
+- No semicolons, 2-space indent, max line length 140 — enforced by [eslint.config.js](eslint.config.js); run `pnpm run lint` before committing.
 - Per-game constants live in that game's `globalVariables.js`; shared engine code goes in `src/common/`.
-- No build step and no test suite — verify changes by running `npm start` and playing the game.
+- No build step and no test suite — verify changes by running `pnpm start` and playing the game.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,5 +41,15 @@ export default [
         "never"
       ],
     }
+  },
+  {
+    // Root-level files (the Express server and this config) run in Node
+    files: ["*.js"],
+    languageOptions: {
+      globals: {
+        process: "readonly",
+        console: "readonly"
+      }
+    }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node .",
-    "lint:fix": "eslint \"./src/**\" --fix",
-    "lint": "eslint \"./src/**\"",
+    "lint:fix": "eslint . --fix",
+    "lint": "eslint .",
     "update-dependencies": "pnpm update --latest"
   },
   "packageManager": "pnpm@11.9.0",


### PR DESCRIPTION
**Why:** The `lint` script only covered `./src/**`, so the Express server ([index.js](https://github.com/cristiadu/mini-js-games/blob/main/index.js)) and the ESLint config itself were never linted — unlinted files drift from the enforced style. Separately, AGENTS.md told contributors to run `npm run lint` / `npm start` in a project whose package manager is pnpm (pinned via `packageManager`), which invites lockfile drift.

**How:** `lint`/`lint:fix` now run `eslint .` (flat config ignores `node_modules` by default), with a small config block declaring Node globals (`process`, `console`) for root-level files so `no-undef` doesn't fire on the server. AGENTS.md command references updated to `pnpm`. `pnpm run lint` passes cleanly over the whole repo.