### PR TITLE
refactor: modernize game loop timing and keyboard input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ A game is any class implementing this contract:
 
 ### `Keyboard.js` — input
 
-A keydown/keyup listener that records pressed key codes in a static map. It self-registers a global singleton on load (`window.GameKeyboard`); games poll input inside `update()` via `Keyboard.isDown(keyCode)`.
+A keydown/keyup listener that records pressed keys in a static map, keyed by `KeyboardEvent.code` (e.g. `'ArrowLeft'`, `'KeyW'`). It self-registers a global singleton on load (`window.GameKeyboard`); games poll input inside `update()` via `Keyboard.isDown(code)`.
 
 ## Games
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,8 @@ export default [
       globals: {
         window: "readonly",
         document: "readonly",
-        requestAnimationFrame: "readonly"
+        requestAnimationFrame: "readonly",
+        performance: "readonly"
       }
     },
     plugins: {

--- a/src/common/GameMachine.js
+++ b/src/common/GameMachine.js
@@ -1,7 +1,6 @@
 const STATES = {
   PLAYING: 0,
   STOPPED: 1,
-  PAUSED: 2,
 }
 
 export default class GameMachine {
@@ -11,8 +10,8 @@ export default class GameMachine {
     this.gameCanvas = document.querySelector(selector)
     this.context = this.gameCanvas.getContext('2d')
     this.now = 0
-    this.ellapsed = 0
-    this.last = new Date().getTime()
+    this.elapsed = 0
+    this.last = performance.now()
     this.fps = cfg.fps || 60
     this.dStep = 1000 / this.fps
     this.accumulator = 0
@@ -24,12 +23,11 @@ export default class GameMachine {
     this.gameCanvas.width = cfg.width
     this.gameCanvas.height = cfg.height
 
-    this.state = STATES.PLAYING
     this.step = () => {
-      this.now = new Date().getTime()
-      this.ellapsed = this.now - this.last
+      this.now = performance.now()
+      this.elapsed = this.now - this.last
       this.last = this.now
-      this.accumulator += Math.min(1000, this.ellapsed)
+      this.accumulator += Math.min(1000, this.elapsed)
 
       while (this.accumulator >= this.dStep) {
         this.game.update()
@@ -38,12 +36,14 @@ export default class GameMachine {
       this.game.draw(this.context, this.accumulator)
 
       if (this.state === STATES.PLAYING) {
-        requestAnimationFrame(this.step, this.gameCanvas)
+        requestAnimationFrame(this.step)
       }
     }
   }
 
   start = () => {
+    this.state = STATES.PLAYING
+    this.last = performance.now()
     this.step()
   }
 }

--- a/src/common/Keyboard.js
+++ b/src/common/Keyboard.js
@@ -1,21 +1,15 @@
 export default class Keyboard {
-  static mappedKeys = {}
+  static pressedKeys = {}
 
   constructor(selector) {
     this.element = selector ? document.querySelector(selector) : document
 
     this.keyDown = (event) => {
-      const evt = window.event || event
-      const code = evt.which || evt.keyCode
-      Keyboard.mappedKeys[code] = true
+      Keyboard.pressedKeys[event.code] = true
     }
 
     this.keyUp = (event) => {
-      const evt = window.event || event
-      const code = evt.which || evt.keyCode
-      if (typeof (Keyboard.mappedKeys[code]) === 'boolean') {
-        Keyboard.mappedKeys[code] = false
-      }
+      Keyboard.pressedKeys[event.code] = false
     }
   }
 
@@ -30,10 +24,7 @@ export default class Keyboard {
   }
 
   static isDown(key) {
-    if (Keyboard.mappedKeys[key]) {
-      return true
-    }
-    return false
+    return Keyboard.pressedKeys[key] === true
   }
 }
 

--- a/src/games/breakout/js/Paddle.js
+++ b/src/games/breakout/js/Paddle.js
@@ -1,6 +1,6 @@
 import Keyboard from '../../../common/Keyboard.js'
 import {
-  KEYCODES, MAX_BOUNCE_ANGLE, PADDLE_COLOR, SIZE_PADDLE, SPEED_PADDLE, THICKNESS_PADDLE,
+  KEYS, MAX_BOUNCE_ANGLE, PADDLE_COLOR, SIZE_PADDLE, SPEED_PADDLE, THICKNESS_PADDLE,
 } from './globalVariables.js'
 
 export default class Paddle {
@@ -20,9 +20,9 @@ export default class Paddle {
   }
 
   checkInput() {
-    if (Keyboard.isDown(KEYCODES.left)) {
+    if (Keyboard.isDown(KEYS.left)) {
       this.X -= SPEED_PADDLE
-    } else if (Keyboard.isDown(KEYCODES.right)) {
+    } else if (Keyboard.isDown(KEYS.right)) {
       this.X += SPEED_PADDLE
     }
   }

--- a/src/games/breakout/js/globalVariables.js
+++ b/src/games/breakout/js/globalVariables.js
@@ -1,6 +1,6 @@
-export const KEYCODES = {
-  left: 37,
-  right: 39,
+export const KEYS = {
+  left: 'ArrowLeft',
+  right: 'ArrowRight',
 }
 
 export const BALL_RADIUS = 5

--- a/src/games/pong/js/Paddle.js
+++ b/src/games/pong/js/Paddle.js
@@ -1,6 +1,6 @@
 import Keyboard from '../../../common/Keyboard.js'
 import {
-  KEYCODES, MAX_BOUNCE_ANGLE, PADDLE_COLOR, PLAYER_TYPE, POSITION, REDUCED_SPEED_AI, SIZE_PADDLE, SPEED_PADDLE, THICKNESS_PADDLE,
+  KEYS, MAX_BOUNCE_ANGLE, PADDLE_COLOR, PLAYER_TYPE, POSITION, REDUCED_SPEED_AI, SIZE_PADDLE, SPEED_PADDLE, THICKNESS_PADDLE,
 } from './globalVariables.js'
 
 export default class Paddle {
@@ -29,15 +29,15 @@ export default class Paddle {
 
   checkInput() {
     if (this.playerType === PLAYER_TYPE.HUMAN) {
-      if (Keyboard.isDown(KEYCODES.down)) {
+      if (Keyboard.isDown(KEYS.down)) {
         this.Y += SPEED_PADDLE
-      } else if (Keyboard.isDown(KEYCODES.up)) {
+      } else if (Keyboard.isDown(KEYS.up)) {
         this.Y -= SPEED_PADDLE
       }
     } else if (this.playerType === PLAYER_TYPE.HUMAN2) {
-      if (Keyboard.isDown(KEYCODES.w)) {
+      if (Keyboard.isDown(KEYS.w)) {
         this.Y -= SPEED_PADDLE
-      } else if (Keyboard.isDown(KEYCODES.s)) {
+      } else if (Keyboard.isDown(KEYS.s)) {
         this.Y += SPEED_PADDLE
       }
     }

--- a/src/games/pong/js/globalVariables.js
+++ b/src/games/pong/js/globalVariables.js
@@ -1,8 +1,8 @@
-export const KEYCODES = {
-  up: 38,
-  down: 40,
-  w: 87,
-  s: 83,
+export const KEYS = {
+  up: 'ArrowUp',
+  down: 'ArrowDown',
+  w: 'KeyW',
+  s: 'KeyS',
 }
 
 export const POSITION = {

--- a/src/games/snake/js/SnakeGame.js
+++ b/src/games/snake/js/SnakeGame.js
@@ -1,7 +1,9 @@
 import Keyboard from '../../../common/Keyboard.js'
 import Food from './Food.js'
 import SnakeHead from './SnakeHead.js'
-import { ARROWS_KEYCODES, DIRECTION, SCREEN_BACKGROUND_COLOR } from './globalVariables.js'
+import {
+  ARROW_KEYS, DIRECTION, ESCAPE_KEY, SCREEN_BACKGROUND_COLOR,
+} from './globalVariables.js'
 
 export default class SnakeGame {
   constructor(w, h) {
@@ -37,21 +39,20 @@ export default class SnakeGame {
   checkInput() {
     let direction = null
     if (!this.gameOver) {
-      if (Keyboard.isDown(ARROWS_KEYCODES.left) && (this.snake.direction !== DIRECTION.RIGHT)) {
+      if (Keyboard.isDown(ARROW_KEYS.left) && (this.snake.direction !== DIRECTION.RIGHT)) {
         direction = DIRECTION.LEFT
-      } else if (Keyboard.isDown(ARROWS_KEYCODES.right) && (this.snake.direction !== DIRECTION.LEFT)) {
+      } else if (Keyboard.isDown(ARROW_KEYS.right) && (this.snake.direction !== DIRECTION.LEFT)) {
         direction = DIRECTION.RIGHT
-      } else if (Keyboard.isDown(ARROWS_KEYCODES.down) && (this.snake.direction !== DIRECTION.UP)) {
+      } else if (Keyboard.isDown(ARROW_KEYS.down) && (this.snake.direction !== DIRECTION.UP)) {
         direction = DIRECTION.DOWN
-      } else if (Keyboard.isDown(ARROWS_KEYCODES.up) && (this.snake.direction !== DIRECTION.DOWN)) {
+      } else if (Keyboard.isDown(ARROW_KEYS.up) && (this.snake.direction !== DIRECTION.DOWN)) {
         direction = DIRECTION.UP
       }
 
       if (direction != null) {
         this.snake.changeDirection(direction)
       }
-    } else if (Keyboard.isDown(27)) {
-      // ESC key was pressed, reset game.
+    } else if (Keyboard.isDown(ESCAPE_KEY)) {
       this.init()
     }
   }

--- a/src/games/snake/js/globalVariables.js
+++ b/src/games/snake/js/globalVariables.js
@@ -1,9 +1,11 @@
-export const ARROWS_KEYCODES = {
-  left: 37,
-  up: 38,
-  right: 39,
-  down: 40,
+export const ARROW_KEYS = {
+  left: 'ArrowLeft',
+  up: 'ArrowUp',
+  right: 'ArrowRight',
+  down: 'ArrowDown',
 }
+
+export const ESCAPE_KEY = 'Escape'
 
 export const DIRECTION = {
   UP: 'Up',


### PR DESCRIPTION
**Why:** `GameMachine` timed its fixed-timestep loop with `new Date().getTime()`, a wall clock that can jump backwards/forwards (NTP sync, DST), which corrupts the accumulator; `performance.now()` is the monotonic standard for game loops. It also passed a non-standard second argument to `requestAnimationFrame` (a legacy Gecko extension) and assigned its state twice in the constructor. `Keyboard` relied on `event.keyCode`/`event.which` and the IE-era `window.event` fallback — `keyCode` is deprecated in the UI Events spec, and numeric codes are also layout-ambiguous; `KeyboardEvent.code` is the modern, layout-independent replacement.

**How:** The loop uses `performance.now()` (with `last` re-anchored in `start()` so state is only PLAYING once started), `elapsed` typo fixed, and the stray rAF argument removed. `Keyboard` stores `KeyboardEvent.code` strings in a `pressedKeys` map; each game's key constants were updated to match (`'ArrowLeft'`, `'KeyW'`, ...), which also replaced snake's magic `isDown(27)` with a named `ESCAPE_KEY` constant. `performance` added to the ESLint browser globals and the AGENTS.md Keyboard section updated.

**Verified:** served the site locally and drove real `KeyboardEvent`s through all three games — snake turns and restarts via Escape, breakout and pong paddles move both directions; no console errors.