### PR TITLE
fix(pong): bounce angle computed from the wrong paddle

### DIFF
--- a/src/games/pong/js/PongGame.js
+++ b/src/games/pong/js/PongGame.js
@@ -41,12 +41,12 @@ export default class PongGame {
 
     if (((this.ball.X + this.ball.radius) >= this.player2Paddle.X) && (this.player2Paddle.Y <= this.ball.Y)
       && ((this.player2Paddle.Y + SIZE_PADDLE) >= this.ball.Y)) {
-      const bounceAngle = this.player1Paddle.getBounceAngle(this.ball.Y)
+      const bounceAngle = this.player2Paddle.getBounceAngle(this.ball.Y)
       this.ball.changeDirection(bounceAngle)
       collides = true
     } else if (((this.ball.X - this.ball.radius) <= (this.player1Paddle.X + THICKNESS_PADDLE))
       && (this.player1Paddle.Y <= this.ball.Y) && ((this.player1Paddle.Y + SIZE_PADDLE) >= this.ball.Y)) {
-      const bounceAngle = this.player2Paddle.getBounceAngle(this.ball.Y)
+      const bounceAngle = this.player1Paddle.getBounceAngle(this.ball.Y)
       this.ball.changeDirection(bounceAngle)
       collides = true
     }

--- a/src/games/pong/js/globalVariables.js
+++ b/src/games/pong/js/globalVariables.js
@@ -23,9 +23,6 @@ export const THICKNESS_PADDLE = 10
 export const SPEED_PADDLE = 4
 export const REDUCED_SPEED_AI = 2
 
-export const PADDLE_INITIAL_X = 0
-export const PADDLE_INITIAL_Y = 0
-
 export const BALL_COLOR = '#A288E3'
 export const PADDLE_COLOR = '#E5DCC5'
 export const SCREEN_BACKGROUND_COLOR = '#000'


### PR DESCRIPTION
**Why:** In `checkCollisionBallwithPaddle`, a hit on the right (AI) paddle called `player1Paddle.getBounceAngle(...)` — the *left* paddle — and a hit on the left paddle asked the right one. Since `getBounceAngle` measures how far from that paddle's own center the ball struck, every rebound angle was a function of where the paddle the ball didn't hit happened to be, producing arbitrary deflections whenever the two paddles were at different heights.

**How:** Each collision branch now computes the angle from the paddle that was actually hit. Also removes the unused `PADDLE_INITIAL_X`/`PADDLE_INITIAL_Y` constants (dead code — paddles position themselves in `init()` from the canvas size).

**Verified in the browser:** with the left paddle parked at the top and the ball striking the right paddle dead center, the ball now bounces straight back (`vY` stays 0, `vX` reverses with the speed-up applied) — previously the angle would have been derived from the distant left paddle.