### PR TITLE
chore: landing page SRI, accessibility and consistency

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
   <meta charset="UTF-8">
   <title>Mini JS Games</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css">
+  <meta name="description" content="A collection of small browser games — Snake, Breakout and Pong — built with vanilla JavaScript on an HTML canvas.">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.3/css/bulma.min.css"
+    integrity="sha384-IJLmUY0f1ePPX6uSCJ9Bxik64/meJmjSYD7dHaJqTXXEBE4y+Oe9P2KBZa/z7p0Q" crossorigin="anonymous">
 </head>
 
 <body>
   <div class="container pt-6">
     <div class="box notification is-primary is-light">
-      <h1 class="is-size-1">JS Mini Games</h1>
+      <h1 class="is-size-1">Mini JS Games</h1>
       <h3 class="is-size-3">
         Introduction
       </h3>
@@ -20,9 +22,9 @@
         Games
       </h3>
       <ul>
-        <li>Snake. <a href="games/snake">play game</a></li>
-        <li>Breakout. <a href="games/breakout">play game</a></li>
-        <li>Pong. <a href="games/pong">play game</a></li>
+        <li><a href="games/snake/">Play Snake</a></li>
+        <li><a href="games/breakout/">Play Breakout</a></li>
+        <li><a href="games/pong/">Play Pong</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
**Why:** The landing page loads Bulma from jsDelivr with no subresource-integrity hash, so a compromised or tampered CDN response would execute style content unchecked — same supply-chain principle as pinning actions to commit SHAs. It was also the only page missing `lang` on `<html>` (screen-reader pronunciation), the `<h1>` said "JS Mini Games" while the title says "Mini JS Games", and the three "play game" links were indistinguishable out of context (WCAG link-purpose guidance).

**How:** Added `integrity="sha384-..."` (computed from the exact bulma@0.9.3 file the page references) and `crossorigin="anonymous"` to the stylesheet link, `lang="en"`, a meta description, a unified heading, and descriptive "Play Snake / Breakout / Pong" link text with trailing-slash hrefs to skip the directory redirect.

**Verified in the browser:** page renders with Bulma styles applied (i.e. the SRI hash validates) and all three links resolve.