### PR TITLE
feat: engine-level pause and game-over handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ The engine lives in `src/common/` and has two pieces:
 - Each frame it accumulates elapsed wall-clock time and calls `game.update()` once per fixed step (`1000 / fps` ms) until the accumulator drains — so game logic advances at a constant rate regardless of frame rate.
 - After updating, it calls `game.draw(context, accumulator)` once with the canvas 2D context.
 - It sets `game.machine = this` back-reference on construction, and `start()` kicks off the loop.
+- **Pause**: pressing `P` toggles PLAYING ↔ PAUSED for every game — while paused, updates stop and the machine draws a "Paused" overlay on top of the frozen frame.
+- **Game over**: a game ends its round by calling `this.machine.gameOver(message)`. The machine freezes updates, draws the message in an overlay with "Press ESC to restart", and on ESC calls `game.init()` and resumes — so `init()` must fully reset the game's state (see BreakoutGame rebuilding its blocks).
 
 A game is any class implementing this contract:
 
@@ -40,7 +42,7 @@ A game is any class implementing this contract:
 |--------|---------|
 | `update()` | Advance game logic by one fixed step (input, movement, collisions) |
 | `draw(ctx, dt)` | Render current state to the canvas 2D context |
-| `init()` | Position entities before the loop starts (called by the game's `main.js`) |
+| `init()` | Position/reset all entities; called by the game's `main.js` before the loop starts and by the machine on every ESC restart |
 
 ### `Keyboard.js` — input
 

--- a/src/common/GameMachine.js
+++ b/src/common/GameMachine.js
@@ -1,6 +1,16 @@
+import Keyboard from './Keyboard.js'
+
+const PAUSE_KEY = 'KeyP'
+const RESTART_KEY = 'Escape'
+
+const OVERLAY_BACKGROUND_COLOR = 'rgba(0, 0, 0, 0.6)'
+const OVERLAY_TEXT_COLOR = '#FFF'
+
 const STATES = {
   PLAYING: 0,
   STOPPED: 1,
+  PAUSED: 2,
+  GAME_OVER: 3,
 }
 
 export default class GameMachine {
@@ -16,6 +26,8 @@ export default class GameMachine {
     this.dStep = 1000 / this.fps
     this.accumulator = 0
     this.state = STATES.STOPPED
+    this.gameOverMessage = ''
+    this.pauseKeyWasDown = false
 
     this.width = cfg.width
     this.height = cfg.height
@@ -27,15 +39,28 @@ export default class GameMachine {
       this.now = performance.now()
       this.elapsed = this.now - this.last
       this.last = this.now
-      this.accumulator += Math.min(1000, this.elapsed)
 
-      while (this.accumulator >= this.dStep) {
-        this.game.update()
-        this.accumulator -= this.dStep
-      }
-      this.game.draw(this.context, this.accumulator)
+      this.handleStateInput()
 
       if (this.state === STATES.PLAYING) {
+        this.accumulator += Math.min(1000, this.elapsed)
+
+        // A game.update() may end the game mid-tick, so re-check the state
+        while (this.state === STATES.PLAYING && this.accumulator >= this.dStep) {
+          this.game.update()
+          this.accumulator -= this.dStep
+        }
+      }
+
+      this.game.draw(this.context, this.accumulator)
+
+      if (this.state === STATES.PAUSED) {
+        this.drawOverlay('Paused', 'Press P to resume')
+      } else if (this.state === STATES.GAME_OVER) {
+        this.drawOverlay(this.gameOverMessage, 'Press ESC to restart')
+      }
+
+      if (this.state !== STATES.STOPPED) {
         requestAnimationFrame(this.step)
       }
     }
@@ -45,5 +70,49 @@ export default class GameMachine {
     this.state = STATES.PLAYING
     this.last = performance.now()
     this.step()
+  }
+
+  // Ends the current round; the machine freezes updates, shows the message
+  // overlay, and restarts the game (via game.init()) when ESC is pressed.
+  gameOver(message) {
+    this.gameOverMessage = message
+    this.state = STATES.GAME_OVER
+  }
+
+  restart() {
+    this.gameOverMessage = ''
+    this.accumulator = 0
+    this.game.init()
+    this.state = STATES.PLAYING
+  }
+
+  handleStateInput() {
+    const pauseKeyIsDown = Keyboard.isDown(PAUSE_KEY)
+    if (pauseKeyIsDown && !this.pauseKeyWasDown) {
+      if (this.state === STATES.PLAYING) {
+        this.state = STATES.PAUSED
+      } else if (this.state === STATES.PAUSED) {
+        this.state = STATES.PLAYING
+      }
+    }
+    this.pauseKeyWasDown = pauseKeyIsDown
+
+    if (this.state === STATES.GAME_OVER && Keyboard.isDown(RESTART_KEY)) {
+      this.restart()
+    }
+  }
+
+  drawOverlay(title, subtitle) {
+    const ctx = this.context
+    ctx.save()
+    ctx.fillStyle = OVERLAY_BACKGROUND_COLOR
+    ctx.fillRect(0, 0, this.width, this.height)
+    ctx.fillStyle = OVERLAY_TEXT_COLOR
+    ctx.textAlign = 'center'
+    ctx.font = '48px monospace'
+    ctx.fillText(title, this.width / 2, this.height / 2 - 16)
+    ctx.font = '20px monospace'
+    ctx.fillText(subtitle, this.width / 2, this.height / 2 + 32)
+    ctx.restore()
   }
 }

--- a/src/games/breakout/js/BreakoutGame.js
+++ b/src/games/breakout/js/BreakoutGame.js
@@ -2,7 +2,7 @@ import Ball from './Ball.js'
 import Block from './Block.js'
 import Paddle from './Paddle.js'
 import {
-  NUM_LINES_BLOCKS, SIZE_PADDLE, SIZE_BLOCK, TEXT_COLOR, THICKNESS_BLOCK, THICKNESS_PADDLE, SCREEN_BACKGROUND_COLOR, GAME_LIVES,
+  NUM_LINES_BLOCKS, SIZE_PADDLE, SIZE_BLOCK, THICKNESS_BLOCK, THICKNESS_PADDLE, SCREEN_BACKGROUND_COLOR, GAME_LIVES,
 } from './globalVariables.js'
 
 export default class BreakoutGame {
@@ -17,12 +17,16 @@ export default class BreakoutGame {
   }
 
   update() {
-    if ((this.activeBlocks > 0) && (this.lives > 0)) {
-      this.ball.update()
-      this.playerPaddle.update()
-      const collidesPaddle = this.checkCollisionBallwithPaddle()
-      const collidesBlock = this.checkCollisionBallwithBlock()
-      this.ball.checkCollisionWithHorizontalWall(collidesPaddle || collidesBlock)
+    this.ball.update()
+    this.playerPaddle.update()
+    const collidesPaddle = this.checkCollisionBallwithPaddle()
+    const collidesBlock = this.checkCollisionBallwithBlock()
+    this.ball.checkCollisionWithHorizontalWall(collidesPaddle || collidesBlock)
+
+    if (this.activeBlocks <= 0) {
+      this.machine.gameOver('You won!')
+    } else if (this.lives <= 0) {
+      this.machine.gameOver('You lost!')
     }
   }
 
@@ -37,12 +41,6 @@ export default class BreakoutGame {
     this.blocks.forEach((block) => {
       block.draw(ctx)
     })
-
-    if (this.activeBlocks <= 0 || this.lives <= 0) {
-      ctx.fillStyle = TEXT_COLOR
-      ctx.font = '48px monospace'
-      ctx.fillText(this.activeBlocks <= 0 ? 'You won!' : 'You lost!', 25, 250)
-    }
   }
   /* eslint-enable no-unused-vars */
 
@@ -91,7 +89,10 @@ export default class BreakoutGame {
     const ballInitialY = window.game.height / 2
     this.ball.init(ballInitialX, ballInitialY)
 
-    // Creating blocks
+    this.lives = GAME_LIVES
+
+    // Rebuilding blocks (init also runs on restart)
+    this.blocks = []
     for (let i = 0; i < NUM_LINES_BLOCKS; i += 1) {
       for (let j = 0; j < window.game.width / SIZE_BLOCK; j += 1) {
         this.blocks.push(new Block())

--- a/src/games/breakout/js/globalVariables.js
+++ b/src/games/breakout/js/globalVariables.js
@@ -16,7 +16,6 @@ export const GAME_LIVES = 3
 export const BALL_COLOR = '#E7F9A9'
 export const PADDLE_COLOR = '#F4AFB4'
 export const SCREEN_BACKGROUND_COLOR = '#000'
-export const TEXT_COLOR = '#FFF'
 
 // 75 degrees
 export const MAX_BOUNCE_ANGLE = (5 * Math.PI) / 12

--- a/src/games/snake/js/SnakeGame.js
+++ b/src/games/snake/js/SnakeGame.js
@@ -1,9 +1,7 @@
 import Keyboard from '../../../common/Keyboard.js'
 import Food from './Food.js'
 import SnakeHead from './SnakeHead.js'
-import {
-  ARROW_KEYS, DIRECTION, ESCAPE_KEY, SCREEN_BACKGROUND_COLOR, TEXT_COLOR,
-} from './globalVariables.js'
+import { ARROW_KEYS, DIRECTION, SCREEN_BACKGROUND_COLOR } from './globalVariables.js'
 
 export default class SnakeGame {
   constructor(w, h) {
@@ -11,29 +9,18 @@ export default class SnakeGame {
     this.height = h
     this.snake = new SnakeHead()
     this.food = new Food()
-    this.gameOver = false
   }
 
   update() {
     this.checkInput()
-    if (!this.gameOver) {
-      this.food.update()
-      this.snake.update()
-    }
+    this.food.update()
+    this.snake.update()
   }
 
   /* eslint-disable no-unused-vars */
   draw(ctx, dt) {
     ctx.fillStyle = SCREEN_BACKGROUND_COLOR
     ctx.fillRect(0, 0, this.width, this.height)
-
-    if (this.gameOver) {
-      ctx.fillStyle = TEXT_COLOR
-      ctx.font = '24px monospace'
-      ctx.fillText('Game Over, press ESC if you want to restart.', 25, 50)
-      return
-    }
-
     this.food.draw(ctx)
     this.snake.draw(ctx)
   }
@@ -41,32 +28,27 @@ export default class SnakeGame {
 
   checkInput() {
     let direction = null
-    if (!this.gameOver) {
-      if (Keyboard.isDown(ARROW_KEYS.left) && (this.snake.direction !== DIRECTION.RIGHT)) {
-        direction = DIRECTION.LEFT
-      } else if (Keyboard.isDown(ARROW_KEYS.right) && (this.snake.direction !== DIRECTION.LEFT)) {
-        direction = DIRECTION.RIGHT
-      } else if (Keyboard.isDown(ARROW_KEYS.down) && (this.snake.direction !== DIRECTION.UP)) {
-        direction = DIRECTION.DOWN
-      } else if (Keyboard.isDown(ARROW_KEYS.up) && (this.snake.direction !== DIRECTION.DOWN)) {
-        direction = DIRECTION.UP
-      }
+    if (Keyboard.isDown(ARROW_KEYS.left) && (this.snake.direction !== DIRECTION.RIGHT)) {
+      direction = DIRECTION.LEFT
+    } else if (Keyboard.isDown(ARROW_KEYS.right) && (this.snake.direction !== DIRECTION.LEFT)) {
+      direction = DIRECTION.RIGHT
+    } else if (Keyboard.isDown(ARROW_KEYS.down) && (this.snake.direction !== DIRECTION.UP)) {
+      direction = DIRECTION.DOWN
+    } else if (Keyboard.isDown(ARROW_KEYS.up) && (this.snake.direction !== DIRECTION.DOWN)) {
+      direction = DIRECTION.UP
+    }
 
-      if (direction != null) {
-        this.snake.changeDirection(direction)
-      }
-    } else if (Keyboard.isDown(ESCAPE_KEY)) {
-      this.init()
+    if (direction != null) {
+      this.snake.changeDirection(direction)
     }
   }
 
   init() {
-    this.gameOver = false
     this.snake.init()
     this.food.init()
   }
 
   gameIsOver() {
-    this.gameOver = true
+    this.machine.gameOver('Game Over')
   }
 }

--- a/src/games/snake/js/globalVariables.js
+++ b/src/games/snake/js/globalVariables.js
@@ -5,8 +5,6 @@ export const ARROW_KEYS = {
   down: 'ArrowDown',
 }
 
-export const ESCAPE_KEY = 'Escape'
-
 export const DIRECTION = {
   UP: 'Up',
   DOWN: 'Down',
@@ -22,6 +20,5 @@ export const SNAKE_INITIAL_Y = 2
 
 export const FOOD_COLOR = '#EB9486'
 export const SCREEN_BACKGROUND_COLOR = '#000'
-export const TEXT_COLOR = '#FFF'
 export const SNAKE_HEAD_COLOR = '#107E7D'
 export const SNAKE_BODY_COLOR = '#C7EFCF'


### PR DESCRIPTION
**Why:** Pause didn't exist anywhere, and end-of-round behavior was hand-rolled per game and inconsistent — snake had its own `gameOver` flag, ESC polling and canvas text; breakout froze on a win/lose message with no way to restart; pong had neither. This is shared game-flow concern, so it belongs in the engine, not copy-pasted into each game.

**How:** `GameMachine` gains PAUSED and GAME_OVER states. `P` toggles pause (edge-detected so a held key doesn't re-toggle every frame); games end a round with `this.machine.gameOver(message)` (the machine back-reference already existed). In both states updates freeze while the frozen frame keeps drawing, with a dimmed overlay showing "Paused / Press P to resume" or the game's message plus "Press ESC to restart"; ESC calls `game.init()` and resumes, making `init()` the full-reset contract. The fixed-timestep loop re-checks state mid-tick so a death during a multi-update frame stops immediately. Snake deletes its flag/ESC/text plumbing (and the now-unused `ESCAPE_KEY`/`TEXT_COLOR` constants), breakout routes win/loss through the machine and now resets lives and rebuilds its block grid in `init()` — gaining restart, which it never had (`init()` used to append blocks without clearing) — and pong gets pause with zero changes. AGENTS.md documents the new contract.

**Verified in the browser (all three games):** P pauses and freezes entities, holding P toggles exactly once, resume continues motion; snake dies mid-tick exactly at the wall (state guard works) and ESC restarts at the start position; breakout shows 'You lost!'/'You won!' and ESC rebuilds exactly 50 visible blocks with 3 lives (not doubled); pong pauses/resumes; overlay text confirmed rendering via canvas pixel scan; no console errors.