### PR TITLE
docs: add JSDoc to every class, method, function and constant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,4 +75,5 @@ The landing page [src/index.html](src/index.html) links to each game. When addin
 - ES modules everywhere; imports include the `.js` extension (enforced by `import-x/extensions`).
 - No semicolons, 2-space indent, max line length 140 — enforced by [eslint.config.js](eslint.config.js); run `pnpm run lint` before committing.
 - Per-game constants live in that game's `globalVariables.js`; shared engine code goes in `src/common/`.
+- JSDoc everything: every class, method, function, and exported constant carries a doc comment (`@param`/`@returns` where they apply).
 - No build step and no test suite — verify changes by running `pnpm start` and playing the game.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,7 @@
+/**
+ * Minimal Express server for local development: serves the static game files
+ * under ./src on PORT (default 4000). Production hosting is GitHub Pages.
+ */
 import express from 'express'
 import path from 'path'
 

--- a/src/common/GameMachine.js
+++ b/src/common/GameMachine.js
@@ -1,11 +1,22 @@
 import Keyboard from './Keyboard.js'
 
+/** KeyboardEvent.code that toggles pause in every game. */
 const PAUSE_KEY = 'KeyP'
+
+/** KeyboardEvent.code that restarts a finished game. */
 const RESTART_KEY = 'Escape'
 
+/** Semi-transparent dim drawn over the frozen frame while paused or game over. */
 const OVERLAY_BACKGROUND_COLOR = 'rgba(0, 0, 0, 0.6)'
+
+/** Color of the overlay title and subtitle text. */
 const OVERLAY_TEXT_COLOR = '#FFF'
 
+/**
+ * Lifecycle states of the machine. Updates only run while PLAYING;
+ * PAUSED and GAME_OVER keep drawing the frozen frame under an overlay.
+ * @enum {number}
+ */
 const STATES = {
   PLAYING: 0,
   STOPPED: 1,
@@ -13,7 +24,33 @@ const STATES = {
   GAME_OVER: 3,
 }
 
+/**
+ * A game the machine can run. Any class with this shape works.
+ *
+ * @typedef {Object} Game
+ * @property {function(): void} update Advances game logic by one fixed step (input, movement, collisions).
+ * @property {function(CanvasRenderingContext2D, number): void} draw Renders the current state; receives the 2D context
+ *   and the accumulator remainder (ms not yet consumed by fixed steps).
+ * @property {function(): void} init Positions/resets all entities; called before the loop starts and on every restart.
+ * @property {GameMachine} [machine] Back-reference set by the machine on construction.
+ */
+
+/**
+ * Fixed-timestep game loop on top of requestAnimationFrame.
+ *
+ * Each frame it accumulates elapsed wall-clock time and calls game.update()
+ * once per fixed step (1000 / fps ms) until the accumulator drains, so game
+ * logic advances at a constant rate regardless of frame rate. It also owns the
+ * cross-game state flow: pause toggling, the game-over screen, and ESC restart.
+ */
 export default class GameMachine {
+  /**
+   * Wires the machine to a game and a canvas and prepares (but does not start) the loop.
+   *
+   * @param {Game} game The game instance to drive; receives a `machine` back-reference.
+   * @param {{width: number, height: number, fps?: number}} cfg Canvas size and optional fixed update rate (default 60).
+   * @param {string} selector CSS selector for the target <canvas> element.
+   */
   constructor(game, cfg, selector) {
     this.game = game
     this.game.machine = this
@@ -35,6 +72,11 @@ export default class GameMachine {
     this.gameCanvas.width = cfg.width
     this.gameCanvas.height = cfg.height
 
+    /**
+     * Runs one frame: handles pause/restart input, drains the accumulator
+     * through game.update() while PLAYING, draws the game and any overlay,
+     * and schedules the next frame.
+     */
     this.step = () => {
       this.now = performance.now()
       this.elapsed = this.now - this.last
@@ -66,19 +108,25 @@ export default class GameMachine {
     }
   }
 
+  /** Enters the PLAYING state and kicks off the frame loop. */
   start = () => {
     this.state = STATES.PLAYING
     this.last = performance.now()
     this.step()
   }
 
-  // Ends the current round; the machine freezes updates, shows the message
-  // overlay, and restarts the game (via game.init()) when ESC is pressed.
+  /**
+   * Ends the current round; the machine freezes updates, shows the message
+   * overlay, and restarts the game (via game.init()) when ESC is pressed.
+   *
+   * @param {string} message Overlay title, e.g. 'Game Over' or 'You won!'.
+   */
   gameOver(message) {
     this.gameOverMessage = message
     this.state = STATES.GAME_OVER
   }
 
+  /** Resets the game through game.init() and resumes playing. */
   restart() {
     this.gameOverMessage = ''
     this.accumulator = 0
@@ -86,6 +134,10 @@ export default class GameMachine {
     this.state = STATES.PLAYING
   }
 
+  /**
+   * Polls the pause and restart keys once per frame. The pause key is
+   * edge-detected so holding it down toggles only once.
+   */
   handleStateInput() {
     const pauseKeyIsDown = Keyboard.isDown(PAUSE_KEY)
     if (pauseKeyIsDown && !this.pauseKeyWasDown) {
@@ -102,6 +154,12 @@ export default class GameMachine {
     }
   }
 
+  /**
+   * Dims the whole canvas and centers a title with a smaller subtitle under it.
+   *
+   * @param {string} title Large overlay headline.
+   * @param {string} subtitle Hint line rendered below the title.
+   */
   drawOverlay(title, subtitle) {
     const ctx = this.context
     ctx.save()

--- a/src/common/Keyboard.js
+++ b/src/common/Keyboard.js
@@ -1,28 +1,56 @@
+/**
+ * Keydown/keyup listener that records pressed keys in a static map, keyed by
+ * KeyboardEvent.code (e.g. 'ArrowLeft', 'KeyW'). A global singleton is
+ * self-registered on load as window.GameKeyboard; games poll input inside
+ * their update() via the static Keyboard.isDown(code).
+ */
 export default class Keyboard {
+  /** @type {Object<string, boolean>} Pressed state per KeyboardEvent.code, shared by all instances. */
   static pressedKeys = {}
 
+  /**
+   * Creates a listener bound to an element (or the whole document).
+   *
+   * @param {string} [selector] Optional CSS selector for the element to listen on; defaults to document.
+   */
   constructor(selector) {
     this.element = selector ? document.querySelector(selector) : document
 
+    /**
+     * Marks the event's key as pressed.
+     * @param {KeyboardEvent} event
+     */
     this.keyDown = (event) => {
       Keyboard.pressedKeys[event.code] = true
     }
 
+    /**
+     * Marks the event's key as released.
+     * @param {KeyboardEvent} event
+     */
     this.keyUp = (event) => {
       Keyboard.pressedKeys[event.code] = false
     }
   }
 
+  /** Attaches the keydown/keyup listeners to the target element. */
   start() {
     this.element.addEventListener('keydown', this.keyDown)
     this.element.addEventListener('keyup', this.keyUp)
   }
 
+  /** Detaches the keydown/keyup listeners from the target element. */
   stop() {
     this.element.removeEventListener('keydown', this.keyDown)
     this.element.removeEventListener('keyup', this.keyUp)
   }
 
+  /**
+   * Reports whether a key is currently held down.
+   *
+   * @param {string} key KeyboardEvent.code to check, e.g. 'ArrowUp'.
+   * @returns {boolean} True while the key is pressed.
+   */
   static isDown(key) {
     return Keyboard.pressedKeys[key] === true
   }

--- a/src/games/breakout/js/Ball.js
+++ b/src/games/breakout/js/Ball.js
@@ -1,6 +1,11 @@
 import { BALL_RADIUS, BALL_INITIAL_SPEED, BALL_COLOR } from './globalVariables.js'
 
+/**
+ * The breakout ball: moves by its velocity each update, bounces off the side
+ * walls and the top, and costs a life when it falls past the bottom edge.
+ */
 export default class Ball {
+  /** Creates a ball at the origin moving straight down; call init() to position it. */
   constructor() {
     this.radius = BALL_RADIUS
     this.initialX = 0
@@ -11,12 +16,18 @@ export default class Ball {
     this.vY = BALL_INITIAL_SPEED
   }
 
+  /** Advances one step along the velocity vector and bounces off the side walls. */
   update() {
     this.X += this.vX
     this.Y += this.vY
     this.checkCollisionWithVerticalWall()
   }
 
+  /**
+   * Renders the ball.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = BALL_COLOR
     ctx.beginPath()
@@ -24,8 +35,14 @@ export default class Ball {
     ctx.fill()
   }
 
+  /**
+   * Handles the top and bottom edges: bounces off the top, and on falling past
+   * the bottom resets the ball and deducts a life. Skipped when the ball
+   * already bounced off the paddle or a block this step.
+   *
+   * @param {boolean} collide True when the ball hit the paddle or a block this step.
+   */
   checkCollisionWithHorizontalWall(collide) {
-    // If didnt collide with block or paddle
     if (!collide) {
       if (this.Y - this.radius <= 0) {
         this.vY = -this.vY
@@ -36,15 +53,20 @@ export default class Ball {
     }
   }
 
+  /** Reverses horizontal direction when touching the left or right wall. */
   checkCollisionWithVerticalWall() {
-    // Means changing direction
     if (((this.X - this.radius) <= 0) || ((this.X + this.radius) >= window.game.width)) {
       this.vX = -this.vX
     }
   }
 
+  /**
+   * Rebounds off the paddle or a block: reverses vertical direction with a
+   * small speed-up and deflects horizontally by the bounce angle.
+   *
+   * @param {number} bounceAngle Angle in radians, negative-to-positive across the surface's width.
+   */
   changeDirection(bounceAngle) {
-    // It hit a paddle, so increase speed.
     if (this.vY < 0) {
       this.vY = -(this.vY + (-0.20) * Math.abs(Math.cos(bounceAngle)))
       this.vX += (1.00) * (-Math.sin(bounceAngle))
@@ -54,6 +76,13 @@ export default class Ball {
     }
   }
 
+  /**
+   * Places the ball and resets its velocity to straight down at initial speed.
+   * The position is remembered for the reset after a lost life.
+   *
+   * @param {number} initialX Starting X position in pixels.
+   * @param {number} initialY Starting Y position in pixels.
+   */
   init(initialX, initialY) {
     this.initialX = initialX
     this.initialY = initialY

--- a/src/games/breakout/js/Block.js
+++ b/src/games/breakout/js/Block.js
@@ -3,7 +3,12 @@ import {
 } from './globalVariables.js'
 import getRandomColor from './utils.js'
 
+/**
+ * One block of the breakable grid. Gets a random color, and is hidden
+ * (show = false) instead of removed once the ball destroys it.
+ */
 export default class Block {
+  /** Creates a visible, randomly colored block; call init() to place it in the grid. */
   constructor() {
     this.X = 0
     this.Y = 0
@@ -11,6 +16,11 @@ export default class Block {
     this.show = true
   }
 
+  /**
+   * Renders the block with a white border, if it has not been destroyed.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     if (this.show) {
       ctx.fillStyle = this.color
@@ -21,12 +31,24 @@ export default class Block {
     }
   }
 
-  // Bounce angle based on how far from the block's center the ball hit
+  /**
+   * Computes the rebound angle for a ball hit, based on how far from the
+   * block's center it struck: 0 at the center up to ±MAX_BOUNCE_ANGLE at the edges.
+   *
+   * @param {number} intersectX X position where the ball hit, in pixels.
+   * @returns {number} Bounce angle in radians.
+   */
   getBounceAngle(intersectX) {
     const relativeIntersection = this.X + (SIZE_BLOCK / 2) - intersectX
     return (relativeIntersection / (SIZE_BLOCK / 2)) * MAX_BOUNCE_ANGLE
   }
 
+  /**
+   * Places the block on the grid.
+   *
+   * @param {number} line Zero-based row index from the top.
+   * @param {number} collumn Zero-based column index from the left.
+   */
   init(line, collumn) {
     this.Y = line * THICKNESS_BLOCK
     this.X = collumn * SIZE_BLOCK

--- a/src/games/breakout/js/BreakoutGame.js
+++ b/src/games/breakout/js/BreakoutGame.js
@@ -5,7 +5,17 @@ import {
   NUM_LINES_BLOCKS, SIZE_PADDLE, SIZE_BLOCK, THICKNESS_BLOCK, THICKNESS_PADDLE, SCREEN_BACKGROUND_COLOR, GAME_LIVES,
 } from './globalVariables.js'
 
+/**
+ * Breakout: bounce the ball off the paddle to clear the block grid before
+ * running out of lives. Implements the GameMachine contract (update/draw/init).
+ */
 export default class BreakoutGame {
+  /**
+   * Creates the paddle, ball and an empty block grid; call init() before starting the loop.
+   *
+   * @param {number} w Playfield width in pixels.
+   * @param {number} h Playfield height in pixels.
+   */
   constructor(w, h) {
     this.width = w
     this.height = h
@@ -16,6 +26,11 @@ export default class BreakoutGame {
     this.activeBlocks = 0
   }
 
+  /**
+   * Advances one fixed step: moves the ball and paddle, resolves collisions,
+   * and ends the round through the machine on a win (no blocks left) or loss
+   * (no lives left).
+   */
   update() {
     this.ball.update()
     this.playerPaddle.update()
@@ -31,6 +46,12 @@ export default class BreakoutGame {
   }
 
   /* eslint-disable no-unused-vars */
+  /**
+   * Clears the playfield and renders the ball, paddle and remaining blocks.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   * @param {number} dt Accumulator remainder in ms (unused).
+   */
   draw(ctx, dt) {
     ctx.fillStyle = SCREEN_BACKGROUND_COLOR
     ctx.fillRect(0, 0, this.width, this.height)
@@ -44,6 +65,11 @@ export default class BreakoutGame {
   }
   /* eslint-enable no-unused-vars */
 
+  /**
+   * Bounces the ball off the paddle when they intersect.
+   *
+   * @returns {boolean} True when the ball hit the paddle this step.
+   */
   checkCollisionBallwithPaddle() {
     let collides = false
 
@@ -57,6 +83,12 @@ export default class BreakoutGame {
     return collides
   }
 
+  /**
+   * Bounces the ball off the first visible block it intersects, hiding that
+   * block and decrementing the active count.
+   *
+   * @returns {boolean} True when the ball hit a block this step.
+   */
   checkCollisionBallwithBlock() {
     let collides = false
 
@@ -80,6 +112,7 @@ export default class BreakoutGame {
     return collides
   }
 
+  /** Resets the paddle, ball and lives, and rebuilds the full block grid (also runs on restart). */
   init() {
     const paddleInitialX = window.game.width / 2
     const paddleInitialY = window.game.height - THICKNESS_PADDLE - 10
@@ -91,7 +124,6 @@ export default class BreakoutGame {
 
     this.lives = GAME_LIVES
 
-    // Rebuilding blocks (init also runs on restart)
     this.blocks = []
     for (let i = 0; i < NUM_LINES_BLOCKS; i += 1) {
       for (let j = 0; j < window.game.width / SIZE_BLOCK; j += 1) {

--- a/src/games/breakout/js/Paddle.js
+++ b/src/games/breakout/js/Paddle.js
@@ -3,22 +3,34 @@ import {
   KEYS, MAX_BOUNCE_ANGLE, PADDLE_COLOR, SIZE_PADDLE, SPEED_PADDLE, THICKNESS_PADDLE,
 } from './globalVariables.js'
 
+/**
+ * The player's paddle: slides horizontally along the bottom of the playfield
+ * under arrow-key control, clamped to the playfield edges.
+ */
 export default class Paddle {
+  /** Creates a paddle at the origin; call init() to position it. */
   constructor() {
     this.X = 0
     this.Y = 0
   }
 
+  /** Advances one step: applies input, then clamps to the playfield. */
   update() {
     this.checkInput()
     this.checkCollisionWithWall()
   }
 
+  /**
+   * Renders the paddle.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = PADDLE_COLOR
     ctx.fillRect(this.X, this.Y, SIZE_PADDLE, THICKNESS_PADDLE)
   }
 
+  /** Moves left/right while the corresponding arrow key is held. */
   checkInput() {
     if (Keyboard.isDown(KEYS.left)) {
       this.X -= SPEED_PADDLE
@@ -27,13 +39,19 @@ export default class Paddle {
     }
   }
 
-  // Used to calculate the angles
+  /**
+   * Computes the rebound angle for a ball hit, based on how far from the
+   * paddle's center it struck: 0 at the center up to ±MAX_BOUNCE_ANGLE at the edges.
+   *
+   * @param {number} intersectX X position where the ball hit, in pixels.
+   * @returns {number} Bounce angle in radians.
+   */
   getBounceAngle(intersectX) {
-    // Y position relative to paddle height.
     const relativeIntersection = this.X + (SIZE_PADDLE / 2) - intersectX
     return (relativeIntersection / (SIZE_PADDLE / 2)) * MAX_BOUNCE_ANGLE
   }
 
+  /** Clamps the paddle inside the playfield's left and right edges. */
   checkCollisionWithWall() {
     if (this.X <= 0) {
       this.X = 0
@@ -42,6 +60,12 @@ export default class Paddle {
     }
   }
 
+  /**
+   * Places the paddle.
+   *
+   * @param {number} initialX Starting X position in pixels.
+   * @param {number} initialY Starting Y position in pixels.
+   */
   init(initialX, initialY) {
     this.X = initialX
     this.Y = initialY

--- a/src/games/breakout/js/globalVariables.js
+++ b/src/games/breakout/js/globalVariables.js
@@ -1,21 +1,44 @@
+/** KeyboardEvent.code values for the paddle movement keys. */
 export const KEYS = {
   left: 'ArrowLeft',
   right: 'ArrowRight',
 }
 
+/** Ball radius in pixels. */
 export const BALL_RADIUS = 5
+
+/** Ball speed in pixels per update at the start of a round. */
 export const BALL_INITIAL_SPEED = 2
+
+/** Paddle width in pixels. */
 export const SIZE_PADDLE = 120
+
+/** Paddle height in pixels. */
 export const THICKNESS_PADDLE = 20
+
+/** Paddle speed in pixels per update while a movement key is held. */
 export const SPEED_PADDLE = 4
+
+/** Block height in pixels. */
 export const THICKNESS_BLOCK = 30
+
+/** Block width in pixels. */
 export const SIZE_BLOCK = 100
+
+/** Number of block rows in the grid. */
 export const NUM_LINES_BLOCKS = 5
+
+/** Lives the player starts a round with. */
 export const GAME_LIVES = 3
 
+/** Ball fill color. */
 export const BALL_COLOR = '#E7F9A9'
+
+/** Paddle fill color. */
 export const PADDLE_COLOR = '#F4AFB4'
+
+/** Playfield background color. */
 export const SCREEN_BACKGROUND_COLOR = '#000'
 
-// 75 degrees
+/** Maximum rebound deflection off a paddle/block edge: 75 degrees, in radians. */
 export const MAX_BOUNCE_ANGLE = (5 * Math.PI) / 12

--- a/src/games/breakout/js/main.js
+++ b/src/games/breakout/js/main.js
@@ -1,6 +1,11 @@
+/**
+ * Breakout entry point: builds the game and its GameMachine, exposes both as
+ * globals (entities reach the game via window.game), and starts the loop.
+ */
 import GameMachine from '../../../common/GameMachine.js'
 import BreakoutGame from './BreakoutGame.js'
 
+/** Canvas size and fixed update rate for this game. */
 const cfg = {
   width: 1000,
   height: 800,

--- a/src/games/breakout/js/utils.js
+++ b/src/games/breakout/js/utils.js
@@ -1,3 +1,8 @@
+/**
+ * Returns a random fully opaque CSS color.
+ *
+ * @returns {string} Color in 'rgb(r,g,b)' form with each channel in [0, 255].
+ */
 export default function getRandomColor() {
   const r = 255 * Math.random() | 0
   const g = 255 * Math.random() | 0

--- a/src/games/pong/js/Ball.js
+++ b/src/games/pong/js/Ball.js
@@ -2,7 +2,12 @@ import {
   BALL_COLOR, BALL_INITIAL_SPEED, BALL_RADIUS, POSITION,
 } from './globalVariables.js'
 
+/**
+ * The pong ball: moves by its velocity each update, bounces off the top and
+ * bottom walls, and triggers scoring when it crosses a side wall.
+ */
 export default class Ball {
+  /** Creates a ball at the origin moving right; call init() to center it. */
   constructor() {
     this.radius = BALL_RADIUS
     this.X = 0
@@ -11,12 +16,18 @@ export default class Ball {
     this.vY = 0
   }
 
+  /** Advances one step along the velocity vector and bounces off the top/bottom walls. */
   update() {
     this.X += this.vX
     this.Y += this.vY
     this.checkCollisionWithHorizontalWall()
   }
 
+  /**
+   * Renders the ball.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = BALL_COLOR
     ctx.beginPath()
@@ -24,8 +35,13 @@ export default class Ball {
     ctx.fill()
   }
 
+  /**
+   * Scores a point for the opponent when the ball crosses a side wall.
+   * Skipped when the ball bounced off a paddle this step.
+   *
+   * @param {boolean} collidePaddle True when the ball hit a paddle this step.
+   */
   checkCollisionWithVerticalWall(collidePaddle) {
-    // Means scoring a point
     if (!collidePaddle) {
       if (this.X - this.radius <= 0) {
         window.game.scorePoint(POSITION.LEFT)
@@ -35,15 +51,20 @@ export default class Ball {
     }
   }
 
+  /** Reverses vertical direction when touching the top or bottom wall. */
   checkCollisionWithHorizontalWall() {
-    // Means changing direction
     if (((this.Y - this.radius) <= 0) || ((this.Y + this.radius) >= window.game.height)) {
       this.vY = -this.vY
     }
   }
 
+  /**
+   * Rebounds off a paddle: reverses horizontal direction with a small
+   * speed-up and deflects vertically by the bounce angle.
+   *
+   * @param {number} bounceAngle Angle in radians, negative-to-positive across the paddle's height.
+   */
   changeDirection(bounceAngle) {
-    // It hit a paddle, so increase speed.
     if (this.vX < 0) {
       this.vX = -(this.vX + (-0.20) * Math.abs(Math.cos(bounceAngle)))
       this.vY += (1.00) * (-Math.sin(bounceAngle))
@@ -53,6 +74,12 @@ export default class Ball {
     }
   }
 
+  /**
+   * Places the ball and resets its velocity to horizontal at initial speed.
+   *
+   * @param {number} initialX Starting X position in pixels.
+   * @param {number} initialY Starting Y position in pixels.
+   */
   init(initialX, initialY) {
     this.X = initialX
     this.Y = initialY

--- a/src/games/pong/js/Paddle.js
+++ b/src/games/pong/js/Paddle.js
@@ -3,7 +3,18 @@ import {
   KEYS, MAX_BOUNCE_ANGLE, PADDLE_COLOR, PLAYER_TYPE, POSITION, REDUCED_SPEED_AI, SIZE_PADDLE, SPEED_PADDLE, THICKNESS_PADDLE,
 } from './globalVariables.js'
 
+/**
+ * A pong paddle: slides vertically along its side of the playfield, driven
+ * either by keyboard input (human) or by tracking the ball (AI). Also keeps
+ * that player's score.
+ */
 export default class Paddle {
+  /**
+   * Creates a paddle for one side; call init() to position it.
+   *
+   * @param {string} pos POSITION value: which side of the playfield the paddle guards.
+   * @param {string} pType PLAYER_TYPE value: what drives the paddle (human input or AI).
+   */
   constructor(pos, pType) {
     this.playerType = pType
     this.position = pos
@@ -12,6 +23,7 @@ export default class Paddle {
     this.points = 0
   }
 
+  /** Advances one step: applies AI or keyboard movement, then clamps to the playfield. */
   update() {
     if (this.playerType === PLAYER_TYPE.AI) {
       this.moveAI()
@@ -22,11 +34,17 @@ export default class Paddle {
     this.checkCollisionWithWall()
   }
 
+  /**
+   * Renders the paddle.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = PADDLE_COLOR
     ctx.fillRect(this.X, this.Y, THICKNESS_PADDLE, SIZE_PADDLE)
   }
 
+  /** Moves up/down from keyboard input: arrows for HUMAN, W/S for HUMAN2. */
   checkInput() {
     if (this.playerType === PLAYER_TYPE.HUMAN) {
       if (Keyboard.isDown(KEYS.down)) {
@@ -43,6 +61,7 @@ export default class Paddle {
     }
   }
 
+  /** Tracks the ball at reduced speed so the AI stays beatable. */
   moveAI() {
     if ((this.Y + SIZE_PADDLE / 2) > window.game.ball.Y) {
       this.Y -= REDUCED_SPEED_AI
@@ -51,12 +70,19 @@ export default class Paddle {
     }
   }
 
-  // Used to calculate the angles
+  /**
+   * Computes the rebound angle for a ball hit, based on how far from the
+   * paddle's center it struck: 0 at the center up to ±MAX_BOUNCE_ANGLE at the edges.
+   *
+   * @param {number} intersectY Y position where the ball hit, in pixels.
+   * @returns {number} Bounce angle in radians.
+   */
   getBounceAngle(intersectY) {
     const relativeIntersection = this.Y + (SIZE_PADDLE / 2) - intersectY
     return (relativeIntersection / (SIZE_PADDLE / 2)) * MAX_BOUNCE_ANGLE
   }
 
+  /** Clamps the paddle inside the playfield's top and bottom edges. */
   checkCollisionWithWall() {
     if (this.Y <= 0) {
       this.Y = 0
@@ -65,6 +91,7 @@ export default class Paddle {
     }
   }
 
+  /** Places the paddle against its side of the playfield, vertically centered, and resets its score. */
   init() {
     if (this.position === POSITION.RIGHT) {
       this.X = window.game.width - THICKNESS_PADDLE

--- a/src/games/pong/js/PongGame.js
+++ b/src/games/pong/js/PongGame.js
@@ -4,7 +4,18 @@ import {
   PLAYER_TYPE, POSITION, SCREEN_BACKGROUND_COLOR, SIZE_PADDLE, TEXT_COLOR, THICKNESS_PADDLE,
 } from './globalVariables.js'
 
+/**
+ * Pong: a human paddle (left, arrow keys) against a simple ball-tracking AI
+ * (right). Endless — points accumulate in the on-screen score.
+ * Implements the GameMachine contract (update/draw/init).
+ */
 export default class PongGame {
+  /**
+   * Creates both paddles and the ball; call init() before starting the loop.
+   *
+   * @param {number} w Playfield width in pixels.
+   * @param {number} h Playfield height in pixels.
+   */
   constructor(w, h) {
     this.width = w
     this.height = h
@@ -13,6 +24,7 @@ export default class PongGame {
     this.ball = new Ball()
   }
 
+  /** Advances one fixed step: moves the ball and paddles, then resolves collisions and scoring. */
   update() {
     this.ball.update()
     this.player1Paddle.update()
@@ -22,6 +34,12 @@ export default class PongGame {
   }
 
   /* eslint-disable no-unused-vars */
+  /**
+   * Clears the playfield and renders the ball, both paddles and the score.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   * @param {number} dt Accumulator remainder in ms (unused).
+   */
   draw(ctx, dt) {
     ctx.fillStyle = SCREEN_BACKGROUND_COLOR
     ctx.fillRect(0, 0, this.width, this.height)
@@ -36,6 +54,12 @@ export default class PongGame {
   }
   /* eslint-enable no-unused-vars */
 
+  /**
+   * Bounces the ball off whichever paddle it intersects, using that paddle's
+   * own position to derive the rebound angle.
+   *
+   * @returns {boolean} True when the ball hit a paddle this step.
+   */
   checkCollisionBallwithPaddle() {
     let collides = false
 
@@ -54,6 +78,12 @@ export default class PongGame {
     return collides
   }
 
+  /**
+   * Awards a point to the player opposite the wall the ball crossed, then
+   * re-centers the ball.
+   *
+   * @param {string} pos POSITION value of the wall the ball went out on.
+   */
   scorePoint(pos) {
     if (pos === POSITION.LEFT) {
       this.player2Paddle.points += 1
@@ -64,6 +94,7 @@ export default class PongGame {
     this.ball.init(this.width / 2, this.height / 2)
   }
 
+  /** Resets both paddles (position and score) and centers the ball. */
   init() {
     this.player1Paddle.init()
     this.player2Paddle.init()

--- a/src/games/pong/js/globalVariables.js
+++ b/src/games/pong/js/globalVariables.js
@@ -1,3 +1,4 @@
+/** KeyboardEvent.code values for the paddle movement keys. */
 export const KEYS = {
   up: 'ArrowUp',
   down: 'ArrowDown',
@@ -5,28 +6,54 @@ export const KEYS = {
   s: 'KeyS',
 }
 
+/**
+ * Playfield sides, used both for paddle placement and for which wall the ball went out on.
+ * @enum {string}
+ */
 export const POSITION = {
   LEFT: 'Left',
   RIGHT: 'Right',
 }
 
+/**
+ * What drives a paddle: arrow-key human, W/S second human, or the ball-tracking AI.
+ * @enum {string}
+ */
 export const PLAYER_TYPE = {
   HUMAN: 'Human',
   HUMAN2: 'Human2',
   AI: 'AI',
 }
 
+/** Ball radius in pixels. */
 export const BALL_RADIUS = 5
+
+/** Ball speed in pixels per update after a serve. */
 export const BALL_INITIAL_SPEED = 1
+
+/** Paddle height in pixels. */
 export const SIZE_PADDLE = 100
+
+/** Paddle width in pixels. */
 export const THICKNESS_PADDLE = 10
+
+/** Human paddle speed in pixels per update while a movement key is held. */
 export const SPEED_PADDLE = 4
+
+/** AI paddle speed in pixels per update, kept below SPEED_PADDLE so the AI is beatable. */
 export const REDUCED_SPEED_AI = 2
 
+/** Ball fill color. */
 export const BALL_COLOR = '#A288E3'
+
+/** Paddle fill color. */
 export const PADDLE_COLOR = '#E5DCC5'
+
+/** Playfield background color. */
 export const SCREEN_BACKGROUND_COLOR = '#000'
+
+/** Score text color. */
 export const TEXT_COLOR = '#C14953'
 
-// 75 degrees
+/** Maximum rebound deflection off a paddle edge: 75 degrees, in radians. */
 export const MAX_BOUNCE_ANGLE = (5 * Math.PI) / 12

--- a/src/games/pong/js/main.js
+++ b/src/games/pong/js/main.js
@@ -1,6 +1,11 @@
+/**
+ * Pong entry point: builds the game and its GameMachine, exposes both as
+ * globals (entities reach the game via window.game), and starts the loop.
+ */
 import GameMachine from '../../../common/GameMachine.js'
 import PongGame from './PongGame.js'
 
+/** Canvas size and fixed update rate for this game. */
 const cfg = {
   width: 1000,
   height: 800,

--- a/src/games/snake/js/Food.js
+++ b/src/games/snake/js/Food.js
@@ -3,13 +3,19 @@ import {
   FOOD_COLOR, FOOD_SIZE, SIZE_SNAKE, TIMEOUT_FOOD,
 } from './globalVariables.js'
 
+/**
+ * The food pellet. Respawns at a random snake-free position when eaten or
+ * after sitting uneaten for TIMEOUT_FOOD updates.
+ */
 export default class Food {
+  /** Creates an unplaced pellet; call init() (or generateFood()) to position it. */
   constructor() {
     this.X = 0
     this.Y = 0
     this.elapsedTime = 0
   }
 
+  /** Counts one update tick and respawns the pellet once it has sat uneaten too long. */
   update() {
     this.elapsedTime += 1
     if (this.elapsedTime >= TIMEOUT_FOOD) {
@@ -17,11 +23,17 @@ export default class Food {
     }
   }
 
+  /**
+   * Renders the pellet.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = FOOD_COLOR
     ctx.fillRect(this.X, this.Y, FOOD_SIZE, FOOD_SIZE)
   }
 
+  /** Moves the pellet to a random in-bounds position that does not overlap the snake. */
   generateFood() {
     let randomX
     let randomY
@@ -36,6 +48,13 @@ export default class Food {
     this.elapsedTime = 0
   }
 
+  /**
+   * Reports whether a candidate pellet position would overlap any part of the snake.
+   *
+   * @param {number} x Candidate X position in pixels.
+   * @param {number} y Candidate Y position in pixels.
+   * @returns {boolean} True when the position intersects the head or any body segment.
+   */
   overlapsSnake(x, y) {
     const overlapsPart = (part) => part.X < x + FOOD_SIZE && part.X + SIZE_SNAKE > x
       && part.Y < y + FOOD_SIZE && part.Y + SIZE_SNAKE > y
@@ -54,6 +73,7 @@ export default class Food {
     return false
   }
 
+  /** Places the pellet for a fresh round. */
   init() {
     this.generateFood()
   }

--- a/src/games/snake/js/SnakeBody.js
+++ b/src/games/snake/js/SnakeBody.js
@@ -1,6 +1,18 @@
 import { DIRECTION, SIZE_SNAKE, SNAKE_BODY_COLOR } from './globalVariables.js'
 
+/**
+ * One segment of the snake's body. Segments form a doubly linked list behind
+ * the head; each update a segment adopts the direction its predecessor had on
+ * the previous tick, which makes turns ripple down the body one cell at a time.
+ */
 export default class SnakeBody {
+  /**
+   * Creates a segment attached behind an existing part.
+   *
+   * @param {number} initialX Starting X position in pixels.
+   * @param {number} initialY Starting Y position in pixels.
+   * @param {SnakeBody|import('./SnakeHead.js').default} previous The part this segment follows (head or another segment).
+   */
   constructor(initialX, initialY, previous) {
     this.next = null
     this.prev = previous
@@ -10,6 +22,7 @@ export default class SnakeBody {
     this.Y = initialY
   }
 
+  /** Moves one cell in the predecessor's previous direction, then updates the next segment. */
   update() {
     // Next element will get direction from before the update
     this.lastDirection = this.direction
@@ -38,6 +51,11 @@ export default class SnakeBody {
     }
   }
 
+  /**
+   * Renders this segment and, recursively, the rest of the tail.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = SNAKE_BODY_COLOR
     ctx.fillRect(this.X, this.Y, SIZE_SNAKE, SIZE_SNAKE)
@@ -46,6 +64,7 @@ export default class SnakeBody {
     }
   }
 
+  /** Appends one segment at the tail, placed one cell behind the last segment's direction of travel. */
   increase() {
     if (this.next != null) {
       this.next.increase()

--- a/src/games/snake/js/SnakeGame.js
+++ b/src/games/snake/js/SnakeGame.js
@@ -3,7 +3,17 @@ import Food from './Food.js'
 import SnakeHead from './SnakeHead.js'
 import { ARROW_KEYS, DIRECTION, SCREEN_BACKGROUND_COLOR } from './globalVariables.js'
 
+/**
+ * Arrow-key snake: eat food to grow, die on self or wall collision.
+ * Implements the GameMachine contract (update/draw/init).
+ */
 export default class SnakeGame {
+  /**
+   * Creates the snake and its food; call init() before starting the loop.
+   *
+   * @param {number} w Playfield width in pixels.
+   * @param {number} h Playfield height in pixels.
+   */
   constructor(w, h) {
     this.width = w
     this.height = h
@@ -11,6 +21,7 @@ export default class SnakeGame {
     this.food = new Food()
   }
 
+  /** Advances one fixed step: applies input, then moves the food timer and the snake. */
   update() {
     this.checkInput()
     this.food.update()
@@ -18,6 +29,12 @@ export default class SnakeGame {
   }
 
   /* eslint-disable no-unused-vars */
+  /**
+   * Clears the playfield and renders the food and the snake.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   * @param {number} dt Accumulator remainder in ms (unused).
+   */
   draw(ctx, dt) {
     ctx.fillStyle = SCREEN_BACKGROUND_COLOR
     ctx.fillRect(0, 0, this.width, this.height)
@@ -26,6 +43,7 @@ export default class SnakeGame {
   }
   /* eslint-enable no-unused-vars */
 
+  /** Polls the arrow keys and turns the snake, disallowing 180-degree reversals. */
   checkInput() {
     let direction = null
     if (Keyboard.isDown(ARROW_KEYS.left) && (this.snake.direction !== DIRECTION.RIGHT)) {
@@ -43,11 +61,13 @@ export default class SnakeGame {
     }
   }
 
+  /** Resets the snake to its starting position/length and spawns fresh food. */
   init() {
     this.snake.init()
     this.food.init()
   }
 
+  /** Ends the round; the machine shows the game-over overlay and handles restart. */
   gameIsOver() {
     this.machine.gameOver('Game Over')
   }

--- a/src/games/snake/js/SnakeHead.js
+++ b/src/games/snake/js/SnakeHead.js
@@ -3,7 +3,13 @@ import {
   DIRECTION, FOOD_SIZE, SIZE_SNAKE, SNAKE_HEAD_COLOR, SNAKE_INITIAL_X, SNAKE_INITIAL_Y,
 } from './globalVariables.js'
 
+/**
+ * The snake's head: moves one cell per update in the current direction,
+ * eats food, and detects self/wall collisions. The rest of the snake hangs
+ * off it as a linked list of SnakeBody segments (via this.body).
+ */
 export default class SnakeHead {
+  /** Creates a head at the starting cell, moving right; call init() to attach the body. */
   constructor() {
     this.body = null
     this.direction = DIRECTION.RIGHT
@@ -12,6 +18,10 @@ export default class SnakeHead {
     this.Y = SNAKE_INITIAL_Y
   }
 
+  /**
+   * Advances one cell in the current direction, grows and respawns the food if
+   * eating, propagates movement down the body, then checks collisions.
+   */
   update() {
     switch (this.direction) {
       case DIRECTION.RIGHT:
@@ -42,12 +52,18 @@ export default class SnakeHead {
     this.checkWallCollision()
   }
 
+  /**
+   * Renders the head and, recursively, every body segment.
+   *
+   * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
+   */
   draw(ctx) {
     ctx.fillStyle = SNAKE_HEAD_COLOR
     ctx.fillRect(this.X, this.Y, SIZE_SNAKE, SIZE_SNAKE)
     this.body.draw(ctx)
   }
 
+  /** Resets position/direction and rebuilds the body at its starting length. */
   init() {
     this.X = SNAKE_INITIAL_X
     this.Y = SNAKE_INITIAL_Y
@@ -59,6 +75,7 @@ export default class SnakeHead {
     this.body.increase()
   }
 
+  /** Ends the game if the head overlaps any body segment. */
   checkBodyCollision() {
     let part = this.body
     while (part != null) {
@@ -70,17 +87,28 @@ export default class SnakeHead {
     }
   }
 
+  /** Ends the game if the head has left the playfield. */
   checkWallCollision() {
     if (this.X < 0 || this.Y < 0 || this.X + SIZE_SNAKE > window.game.width || this.Y + SIZE_SNAKE > window.game.height) {
       window.game.gameIsOver()
     }
   }
 
+  /**
+   * Turns the head, remembering the previous direction for the body to follow.
+   *
+   * @param {string} updatedDirection One of the DIRECTION values.
+   */
   changeDirection(updatedDirection) {
     this.lastDirection = this.direction
     this.direction = updatedDirection
   }
 
+  /**
+   * Reports whether the head currently overlaps the food.
+   *
+   * @returns {boolean} True when the head and food rectangles intersect.
+   */
   isEatingFood() {
     if (this.X < window.game.food.X + FOOD_SIZE && this.X + SIZE_SNAKE > window.game.food.X
       && this.Y < window.game.food.Y + FOOD_SIZE && SIZE_SNAKE + this.Y > window.game.food.Y) {

--- a/src/games/snake/js/globalVariables.js
+++ b/src/games/snake/js/globalVariables.js
@@ -1,3 +1,4 @@
+/** KeyboardEvent.code values for the movement keys. */
 export const ARROW_KEYS = {
   left: 'ArrowLeft',
   up: 'ArrowUp',
@@ -5,6 +6,10 @@ export const ARROW_KEYS = {
   down: 'ArrowDown',
 }
 
+/**
+ * Travel directions for the head and body segments.
+ * @enum {string}
+ */
 export const DIRECTION = {
   UP: 'Up',
   DOWN: 'Down',
@@ -12,13 +17,29 @@ export const DIRECTION = {
   RIGHT: 'Right',
 }
 
+/** Update ticks a pellet may sit uneaten before it respawns elsewhere. */
 export const TIMEOUT_FOOD = 3000
+
+/** Food pellet width/height in pixels. */
 export const FOOD_SIZE = 6
+
+/** Cell size in pixels: the snake is drawn and moves in steps of this size. */
 export const SIZE_SNAKE = 8
+
+/** Head starting X position in pixels. */
 export const SNAKE_INITIAL_X = 2
+
+/** Head starting Y position in pixels. */
 export const SNAKE_INITIAL_Y = 2
 
+/** Food pellet fill color. */
 export const FOOD_COLOR = '#EB9486'
+
+/** Playfield background color. */
 export const SCREEN_BACKGROUND_COLOR = '#000'
+
+/** Head fill color. */
 export const SNAKE_HEAD_COLOR = '#107E7D'
+
+/** Body segment fill color. */
 export const SNAKE_BODY_COLOR = '#C7EFCF'

--- a/src/games/snake/js/main.js
+++ b/src/games/snake/js/main.js
@@ -1,6 +1,11 @@
+/**
+ * Snake entry point: builds the game and its GameMachine, exposes both as
+ * globals (entities reach the game via window.game), and starts the loop.
+ */
 import GameMachine from '../../../common/GameMachine.js'
 import SnakeGame from './SnakeGame.js'
 
+/** Canvas size and fixed update rate for this game. */
 const cfg = {
   width: 796,
   height: 796,

--- a/src/games/snake/js/utils.js
+++ b/src/games/snake/js/utils.js
@@ -1,3 +1,10 @@
+/**
+ * Returns a random integer between min and max, both inclusive.
+ *
+ * @param {number} min Lower bound (inclusive).
+ * @param {number} max Upper bound (inclusive).
+ * @returns {number} Random integer in [min, max].
+ */
 export default function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min
 }


### PR DESCRIPTION
**Why:** None of the code carried structured documentation — readers had to infer each method's role, parameter meanings, and units (pixels, radians, ticks) from the implementation. JSDoc makes that explicit and gives editors type-aware hover/completion even in a plain-JS project.

**What:** Doc comments on every class, constructor, method, standalone function, and exported constant across `src/common/`, all three games, and the Express dev server — with `@param`/`@returns` types where they apply (`CanvasRenderingContext2D`, radians, pixel units, `@enum` on the closed value sets). `GameMachine` gains a `@typedef {Object} Game` documenting the update/draw/init contract it drives, including the pause/game-over API from #137. The few pre-existing inline `//` comments were folded into the new doc blocks rather than duplicated. AGENTS.md records the convention.

**Reviewer notes:** The diff is documentation-only — every deleted line is an old `//` comment absorbed into a JSDoc block (verified by inspecting all deletions), and `pnpm run lint` passes.