### PR TITLE
fix(snake): snake spawns with body segments off-screen

### DIFF
--- a/src/games/snake/js/globalVariables.js
+++ b/src/games/snake/js/globalVariables.js
@@ -28,11 +28,11 @@ export const FOOD_SIZE = 6
 /** Cell size in pixels: the snake is drawn and moves in steps of this size. */
 export const SIZE_SNAKE = 8
 
-/** Head starting X position in pixels. */
-export const SNAKE_INITIAL_X = 2
+/** Head starting X position in pixels: two grid cells in, so the two starting body segments spawn on-screen. */
+export const SNAKE_INITIAL_X = SIZE_SNAKE * 2
 
-/** Head starting Y position in pixels. */
-export const SNAKE_INITIAL_Y = 2
+/** Head starting Y position in pixels: aligned to the same grid as the X position. */
+export const SNAKE_INITIAL_Y = SIZE_SNAKE * 2
 
 /** Food pellet fill color. */
 export const FOOD_COLOR = '#EB9486'


### PR DESCRIPTION
Playing the game shows the snake starting with only its head visible: the head spawns at pixel (2, 2) and the two starting body segments are placed behind it at X=-6 and X=-14, off the left edge of the canvas. This change starts the head two grid cells in at (16, 16), so the whole snake spawns on-screen and stays aligned to the 8px movement grid. Verified by playing: spawn is fully visible, and movement, eating/growth, wall death and restart all behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)