### PR TITLE
fix(pong): ball trapped against a covering paddle and off-center spawn

### DIFF
--- a/src/games/pong/js/Paddle.js
+++ b/src/games/pong/js/Paddle.js
@@ -88,12 +88,11 @@ export default class Paddle {
   init = () => {
     if (this.position === POSITION.RIGHT) {
       this.X = window.game.width - THICKNESS_PADDLE
-      this.Y = window.game.height / 2
     } else if (this.position === POSITION.LEFT) {
       this.X = 0
-      this.Y = window.game.height / 2
     }
 
+    this.Y = (window.game.height - SIZE_PADDLE) / 2
     this.points = 0
   }
 }

--- a/src/games/pong/js/PongGame.js
+++ b/src/games/pong/js/PongGame.js
@@ -55,23 +55,29 @@ export default class PongGame {
   /* eslint-enable no-unused-vars */
 
   /**
-   * Bounces the ball off whichever paddle it intersects, using that paddle's
-   * own position to derive the rebound angle.
+   * Bounces the ball off whichever paddle it intersects while moving toward
+   * it, using that paddle's own position to derive the rebound angle, then
+   * rests the ball on the paddle's face so it cannot collide again on the
+   * next step.
    *
    * @returns {boolean} True when the ball hit a paddle this step.
    */
   checkCollisionBallwithPaddle = () => {
     let collides = false
 
-    if (((this.ball.X + this.ball.radius) >= this.player2Paddle.X) && (this.player2Paddle.Y <= this.ball.Y)
+    if ((this.ball.vX > 0)
+      && ((this.ball.X + this.ball.radius) >= this.player2Paddle.X) && (this.player2Paddle.Y <= this.ball.Y)
       && ((this.player2Paddle.Y + SIZE_PADDLE) >= this.ball.Y)) {
       const bounceAngle = this.player2Paddle.getBounceAngle(this.ball.Y)
       this.ball.changeDirection(bounceAngle)
+      this.ball.X = this.player2Paddle.X - this.ball.radius
       collides = true
-    } else if (((this.ball.X - this.ball.radius) <= (this.player1Paddle.X + THICKNESS_PADDLE))
+    } else if ((this.ball.vX < 0)
+      && ((this.ball.X - this.ball.radius) <= (this.player1Paddle.X + THICKNESS_PADDLE))
       && (this.player1Paddle.Y <= this.ball.Y) && ((this.player1Paddle.Y + SIZE_PADDLE) >= this.ball.Y)) {
       const bounceAngle = this.player1Paddle.getBounceAngle(this.ball.Y)
       this.ball.changeDirection(bounceAngle)
+      this.ball.X = this.player1Paddle.X + THICKNESS_PADDLE + this.ball.radius
       collides = true
     }
 


### PR DESCRIPTION
Playing the game surfaced two bugs. First, when the ball beat a paddle and that paddle then slid over it near the wall (the ball-chasing AI does this constantly), the collision check matched on every update: with no direction guard the ball's horizontal velocity flipped each step while gaining speed, so it jittered against the wall through ~40 hits, the earned point was suppressed, and the ball finally shot out ~14x faster than serve speed. Each paddle now only bounces a ball moving toward it and rests the ball on its face after the bounce, so a ball that has fully beaten a paddle scores normally. Second, both paddles spawned with their top edge at the vertical center (height / 2) rather than being centered, so the flat opening serve always struck the paddle's exact top edge and rebounded at the maximum 75° angle — paddles are now vertically centered. Verified by replaying: the trap scenario produces a single clean return at normal speed, and scoring past a beaten paddle works.