### PR TITLE
feat(pong): smarter AI paddle tracking

### DIFF
--- a/src/games/pong/js/Paddle.js
+++ b/src/games/pong/js/Paddle.js
@@ -54,13 +54,23 @@ export default class Paddle {
     }
   }
 
-  /** Tracks the ball at reduced speed so the AI stays beatable. */
+  /**
+   * Tracks the ball at reduced speed while it approaches, and drifts back to
+   * the vertical center once it moves away, so the AI is positioned for the
+   * next return but stays beatable. Movement stops inside a small dead zone
+   * around the target so the paddle does not jitter once aligned.
+   */
   moveAI = () => {
-    if ((this.Y + SIZE_PADDLE / 2) > window.game.ball.Y) {
-      this.Y -= REDUCED_SPEED_AI
-    } else if ((this.Y + SIZE_PADDLE / 2) < window.game.ball.Y) {
-      this.Y += REDUCED_SPEED_AI
+    const ball = window.game.ball
+    const ballApproaching = this.position === POSITION.RIGHT ? ball.vX > 0 : ball.vX < 0
+    const targetY = ballApproaching ? ball.Y : window.game.height / 2
+    const distance = targetY - (this.Y + SIZE_PADDLE / 2)
+
+    if (Math.abs(distance) <= REDUCED_SPEED_AI) {
+      return
     }
+
+    this.Y += distance > 0 ? REDUCED_SPEED_AI : -REDUCED_SPEED_AI
   }
 
   /**


### PR DESCRIPTION
The AI paddle chased the ball's Y position on every update — even when the ball was moving away from it — and dithered up and down around the target because it always moved a full step when off by a single pixel. It now only tracks the ball while the ball is approaching its side, drifts back to the vertical center otherwise so it's positioned for the next return, and holds still inside a small dead zone so it no longer jitters once aligned. AI speed is unchanged, so it stays beatable. Verified by playing: the paddle recenters and sits still while the ball is away, returns angled incoming shots, and steep corner shots still get past it.