### PR TITLE
feat(snake): food varieties and a win at 30 segments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ A keydown/keyup listener that records pressed keys in a static map, keyed by `Ke
 
 | Game | Path | Notes |
 |------|------|-------|
-| Snake | `src/games/snake/` | Arrow-key snake; eat food, grow, die on self/wall collision |
+| Snake | `src/games/snake/` | Arrow-key snake; eat food (3 varieties with different growth/rarity), grow, die on self/wall collision, win at 30 segments |
 | Breakout | `src/games/breakout/` | Paddle + ball; clear the block grid |
 | Pong | `src/games/pong/` | Human (W/S or arrows) vs. simple AI paddle |
 

--- a/src/games/snake/js/Food.js
+++ b/src/games/snake/js/Food.js
@@ -1,11 +1,12 @@
 import getRandomInt from './utils.js'
 import {
-  FOOD_COLOR, FOOD_SIZE, SIZE_SNAKE, TIMEOUT_FOOD,
+  FOOD_SIZE, FOOD_TYPES, SIZE_SNAKE, TIMEOUT_FOOD,
 } from './globalVariables.js'
 
 /**
- * The food pellet. Respawns at a random snake-free position when eaten or
- * after sitting uneaten for TIMEOUT_FOOD updates.
+ * The food pellet. Respawns at a random snake-free position as a randomly
+ * picked variety (see FOOD_TYPES) when eaten or after sitting uneaten for
+ * TIMEOUT_FOOD updates.
  */
 export default class Food {
   /** Creates an unplaced pellet; call init() (or generateFood()) to position it. */
@@ -13,6 +14,7 @@ export default class Food {
     this.X = 0
     this.Y = 0
     this.elapsedTime = 0
+    this.type = FOOD_TYPES.REGULAR
   }
 
   /** Counts one update tick and respawns the pellet once it has sat uneaten too long. */
@@ -29,11 +31,11 @@ export default class Food {
    * @param {CanvasRenderingContext2D} ctx Canvas 2D context.
    */
   draw = (ctx) => {
-    ctx.fillStyle = FOOD_COLOR
+    ctx.fillStyle = this.type.color
     ctx.fillRect(this.X, this.Y, FOOD_SIZE, FOOD_SIZE)
   }
 
-  /** Moves the pellet to a random in-bounds position that does not overlap the snake. */
+  /** Moves the pellet to a random in-bounds position that does not overlap the snake, as a freshly picked variety. */
   generateFood = () => {
     let randomX
     let randomY
@@ -45,7 +47,28 @@ export default class Food {
 
     this.X = randomX
     this.Y = randomY
+    this.type = this.pickRandomType()
     this.elapsedTime = 0
+  }
+
+  /**
+   * Picks the next pellet's variety at random, weighted by each variety's spawn weight.
+   *
+   * @returns {{color: string, growth: number, weight: number}} One of the FOOD_TYPES entries.
+   */
+  pickRandomType = () => {
+    const types = Object.values(FOOD_TYPES)
+    const totalWeight = types.reduce((sum, type) => sum + type.weight, 0)
+    let roll = Math.random() * totalWeight
+
+    for (const type of types) {
+      roll -= type.weight
+      if (roll < 0) {
+        return type
+      }
+    }
+
+    return FOOD_TYPES.REGULAR
   }
 
   /**

--- a/src/games/snake/js/SnakeGame.js
+++ b/src/games/snake/js/SnakeGame.js
@@ -1,10 +1,13 @@
 import Keyboard from '../../../common/Keyboard.js'
 import Food from './Food.js'
 import SnakeHead from './SnakeHead.js'
-import { CONTROLS, DIRECTION, SCREEN_BACKGROUND_COLOR } from './globalVariables.js'
+import {
+  CONTROLS, DIRECTION, SCREEN_BACKGROUND_COLOR, WIN_LENGTH,
+} from './globalVariables.js'
 
 /**
- * Arrow-key snake: eat food to grow, die on self or wall collision.
+ * Arrow-key snake: eat food to grow, die on self or wall collision, win by
+ * reaching WIN_LENGTH segments.
  * Implements the GameMachine contract (update/draw/init).
  */
 export default class SnakeGame {
@@ -21,11 +24,32 @@ export default class SnakeGame {
     this.food = new Food()
   }
 
-  /** Advances one fixed step: applies input, then moves the food timer and the snake. */
+  /** Advances one fixed step: applies input, moves the food timer and the snake, then checks for the win. */
   update = () => {
     this.checkInput()
     this.food.update()
     this.snake.update()
+    this.checkWin()
+  }
+
+  /**
+   * Ends the round with a win once the snake has reached the winning length.
+   * Skipped when the round already ended this step (dying takes precedence
+   * over growing on the same move).
+   */
+  checkWin = () => {
+    if (this.machine.gameOverMessage !== '') {
+      return
+    }
+
+    let length = 1
+    for (let part = this.snake.body; part != null; part = part.next) {
+      length += 1
+    }
+
+    if (length >= WIN_LENGTH) {
+      this.machine.gameOver('You won!')
+    }
   }
 
   /* eslint-disable no-unused-vars */

--- a/src/games/snake/js/SnakeHead.js
+++ b/src/games/snake/js/SnakeHead.js
@@ -19,8 +19,9 @@ export default class SnakeHead {
   }
 
   /**
-   * Advances one cell in the current direction, grows and respawns the food if
-   * eating, propagates movement down the body, then checks collisions.
+   * Advances one cell in the current direction, grows by the eaten variety's
+   * growth and respawns the food if eating, propagates movement down the
+   * body, then checks collisions.
    */
   update = () => {
     switch (this.direction) {
@@ -42,7 +43,9 @@ export default class SnakeHead {
     }
 
     if (this.isEatingFood()) {
-      this.body.increase()
+      for (let i = 0; i < window.game.food.type.growth; i += 1) {
+        this.body.increase()
+      }
       window.game.food.generateFood()
     }
 

--- a/src/games/snake/js/globalVariables.js
+++ b/src/games/snake/js/globalVariables.js
@@ -34,8 +34,20 @@ export const SNAKE_INITIAL_X = SIZE_SNAKE * 2
 /** Head starting Y position in pixels: aligned to the same grid as the X position. */
 export const SNAKE_INITIAL_Y = SIZE_SNAKE * 2
 
-/** Food pellet fill color. */
-export const FOOD_COLOR = '#EB9486'
+/**
+ * The food varieties a pellet can spawn as: color tells them apart on
+ * screen, growth is how many segments eating one adds, and weight is the
+ * variety's relative spawn chance (7:2:1).
+ * @enum {{color: string, growth: number, weight: number}}
+ */
+export const FOOD_TYPES = {
+  REGULAR: { color: '#EB9486', growth: 1, weight: 7 },
+  BONUS: { color: '#6EA4BF', growth: 2, weight: 2 },
+  GOLDEN: { color: '#FFD700', growth: 3, weight: 1 },
+}
+
+/** Snake length (head plus body segments) that wins the game. */
+export const WIN_LENGTH = 30
 
 /** Playfield background color. */
 export const SCREEN_BACKGROUND_COLOR = '#000'


### PR DESCRIPTION
The single food pellet becomes three varieties chosen by weighted random spawn (roughly 7:2:1): the familiar salmon pellet grows the snake by one segment, a blue bonus pellet by two, and a rare golden pellet by three — same size, told apart by color. The game also gains a positive ending: reaching 30 segments shows the win overlay, while dying on the same move still counts as a death. Verified by playing: each variety grows the snake by its amount with segments staying contiguous, spawn rates match the weights over 2000 picks, the win triggers at exactly 30, and wall/self death and restart behave as before.