### PR TITLE
feat(pong): first to 5 points wins the match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ A keydown/keyup listener that records pressed keys in a static map, keyed by `Ke
 |------|------|-------|
 | Snake | `src/games/snake/` | Arrow-key snake; eat food, grow, die on self/wall collision |
 | Breakout | `src/games/breakout/` | Paddle + ball; clear the block grid |
-| Pong | `src/games/pong/` | Human (W/S or arrows) vs. simple AI paddle |
+| Pong | `src/games/pong/` | Human (arrows) vs. simple AI paddle; first to 5 points wins |
 
 Every game follows the same layout:
 

--- a/src/games/pong/js/PongGame.js
+++ b/src/games/pong/js/PongGame.js
@@ -1,12 +1,12 @@
 import Ball from './Ball.js'
 import Paddle from './Paddle.js'
 import {
-  PLAYER_TYPE, POSITION, SCREEN_BACKGROUND_COLOR, SIZE_PADDLE, TEXT_COLOR, THICKNESS_PADDLE,
+  PLAYER_TYPE, POSITION, SCREEN_BACKGROUND_COLOR, SIZE_PADDLE, TEXT_COLOR, THICKNESS_PADDLE, WINNING_SCORE,
 } from './globalVariables.js'
 
 /**
  * Pong: a human paddle (left, arrow keys) against a simple ball-tracking AI
- * (right). Endless — points accumulate in the on-screen score.
+ * (right). First to WINNING_SCORE points wins the match.
  * Implements the GameMachine contract (update/draw/init).
  */
 export default class PongGame {
@@ -86,7 +86,8 @@ export default class PongGame {
 
   /**
    * Awards a point to the player opposite the wall the ball crossed, then
-   * re-centers the ball.
+   * re-centers the ball for the next serve — or ends the match once either
+   * player reaches the winning score.
    *
    * @param {string} pos POSITION value of the wall the ball went out on.
    */
@@ -95,6 +96,12 @@ export default class PongGame {
       this.player2Paddle.points += 1
     } else if (pos === POSITION.RIGHT) {
       this.player1Paddle.points += 1
+    }
+
+    if (this.player1Paddle.points >= WINNING_SCORE) {
+      this.machine.gameOver('You won!')
+    } else if (this.player2Paddle.points >= WINNING_SCORE) {
+      this.machine.gameOver('You lost!')
     }
 
     this.ball.init(this.width / 2, this.height / 2)

--- a/src/games/pong/js/globalVariables.js
+++ b/src/games/pong/js/globalVariables.js
@@ -37,6 +37,9 @@ export const BALL_RADIUS = 5
 /** Ball speed in pixels per update after a serve. */
 export const BALL_INITIAL_SPEED = 1
 
+/** Points a player needs to win the match. */
+export const WINNING_SCORE = 5
+
 /** Paddle height in pixels. */
 export const SIZE_PADDLE = 100
 


### PR DESCRIPTION
Pong was endless — points accumulated forever with no outcome. A match now ends through the engine's game-over overlay once either side reaches 5 points: 'You won!' when the human gets there first, 'You lost!' when the AI does, and ESC restarts a fresh match at 0-0. Verified by playing: the match keeps going at 4 points, ends with the right message for whichever side reaches 5, and restart resets both scores.